### PR TITLE
Handle mixed required params

### DIFF
--- a/flask_oasschema.py
+++ b/flask_oasschema.py
@@ -76,15 +76,16 @@ def extract_body_schema(schema, uri_path, method):
 
 def extract_query_schema(parameters):
 
+    query_params = [param for param in parameters if param.get("in", "") == "query"]
     schema = {
         "type": "object",
         "properties": {
             parameter["name"]: schema_property(parameter)
-            for parameter in parameters if parameter.get("in", "") == "query"
+            for parameter in query_params
         },
         "required": [
             parameter["name"]
-            for parameter in parameters if parameter.get("required", False)
+            for parameter in query_params if parameter.get("required", False)
         ]
     }
 
@@ -96,15 +97,16 @@ def extract_query_schema(parameters):
 
 def extract_path_schema(parameters):
 
+    path_params = [param for param in parameters if param.get("in", "") == "path"]
     schema = {
         "type": "object",
         "properties": {
             parameter["name"]: schema_property(parameter)
-            for parameter in parameters if parameter.get("in", "") == "path"
+            for parameter in path_params
         },
         "required": [
             parameter["name"]
-            for parameter in parameters if parameter.get("required", False)
+            for parameter in path_params if parameter.get("required", False)
         ]
     }
 

--- a/schemas/oas.json
+++ b/schemas/oas.json
@@ -83,6 +83,31 @@
                     }
                 }
             }
+        },
+        "/books/by-author/{author}": {
+            "get": {
+                "operationId": "GET_books_author_filter",
+                "parameters": [
+                    {
+                        "name": "author",
+                        "in": "path",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "title",
+                        "in": "query",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": "",
+                        "schema": {}
+                    }
+                }
+            }
         }
     },
     "definitions": {

--- a/tests.py
+++ b/tests.py
@@ -40,6 +40,12 @@ def books_get_title():
     return 'success'
 
 
+@app.route('/books/by-author/<author>', methods=['GET'])
+@validate_request()
+def books_by_author_and_title_filter(author):
+    return 'success'
+
+
 @app.errorhandler(ValidationError)
 def on_error(e):
     return 'error'
@@ -106,6 +112,15 @@ class JsonSchemaTests(unittest.TestCase):
     def test_path_param_valid(self):
         r = client.get(
             '/books/id/{}'.format(uuid4()),
+            query_string={
+                'title': '1234'
+            }
+        )
+        self.assertIn(b'success', r.data)
+
+    def test_mixed_required_params(self):
+        r = client.get(
+            '/books/by-author/{}'.format('bob'),
             query_string={
                 'title': '1234'
             }


### PR DESCRIPTION
Validation fails if `path` and `query` types parameters are both required.