### PR TITLE
parse the url before sending it to parse_qsl

### DIFF
--- a/flask_oasschema.py
+++ b/flask_oasschema.py
@@ -10,7 +10,7 @@ install_aliases()
 
 import os
 from functools import wraps
-from urllib.parse import parse_qsl
+from urllib.parse import parse_qsl, urlparse
 
 try:
     import simplejson as json
@@ -151,11 +151,8 @@ def validate_request():
                 validate(request.view_args, path_schema)
 
             # validate query string params
-            query = dict(parse_qsl(request.query_string))
-            query = {
-                key.decode("utf8"): convert_type(query[key])
-                for key in query
-            }
+            parsed_url = urlparse(request.url)
+            query = dict(parse_qsl(parsed_url.query))
 
             request_parameters = schema["paths"][uri_path][method].get("parameters")
             if request_parameters:


### PR DESCRIPTION
Oftentimes, we end up getting unicode chars in the request attributes. We'd need to handle these errors without having to raise a `UnicodeDecodeError`.


In the current scenario, the query string params are fed into the `parse_qsl` method to be parsed and returned as a list of key-val pairs. However, this does not treat unicode chars very well. Ideally, we'll need to mend the encoding then pass the query string params. `urlparse` can do this for us and then we can extract the query string params from the repaired url.